### PR TITLE
修改响应Notification进入聊天后，可能误判不抢的Bug

### DIFF
--- a/app/src/main/java/xyz/monkeytong/hongbao/services/HongbaoService.java
+++ b/app/src/main/java/xyz/monkeytong/hongbao/services/HongbaoService.java
@@ -124,6 +124,9 @@ public class HongbaoService extends AccessibilityService {
         if (parcelable instanceof Notification) {
             Notification notification = (Notification) parcelable;
             try {
+                /* 清除signature,避免进入会话后误判*/
+                signature.cleanSignature();
+
                 notification.contentIntent.send();
             } catch (PendingIntent.CanceledException e) {
                 e.printStackTrace();

--- a/app/src/main/java/xyz/monkeytong/hongbao/utils/HongbaoSignature.java
+++ b/app/src/main/java/xyz/monkeytong/hongbao/utils/HongbaoSignature.java
@@ -61,4 +61,11 @@ public class HongbaoSignature {
         }
         return result;
     }
+
+    public void cleanSignature(){
+        this.content = "";
+        this.time = "";
+        this.sender ="";
+    }
+
 }


### PR DESCRIPTION
Notification发生时且匹配[微信红包]后，必然有新红包。
清除Signatur，以避免此红包是上个红包同一人所发，且content相同出现误判的情况
