### PR TITLE
修复进入发红包界面会按下按键2的情况

### DIFF
--- a/app/src/main/java/xyz/monkeytong/hongbao/services/HongbaoService.java
+++ b/app/src/main/java/xyz/monkeytong/hongbao/services/HongbaoService.java
@@ -162,7 +162,8 @@ public class HongbaoService extends AccessibilityService {
         }
 
         /* 戳开红包，红包还没抢完，遍历节点匹配“拆红包” */
-        AccessibilityNodeInfo node2 = (this.rootNodeInfo.getChildCount() > 3) ? this.rootNodeInfo.getChild(3) : null;
+        AccessibilityNodeInfo node2 = (this.rootNodeInfo.getChildCount() > 3 && this.rootNodeInfo.getChildCount() < 10) ? this.rootNodeInfo.getChild(3) : null;
+
         if (node2 != null && node2.getClassName().equals("android.widget.Button")) {
             mUnpackNode = node2;
             mNeedUnpack = true;


### PR DESCRIPTION
进入发红包界面时，界面的nodeInfo满足 “/\* 戳开红包，红包还没抢完，遍历节点匹配“拆红包” */”情况，即rootNode 不为空，并且第四个字元素也为button，导致会误认为是打开了红包了，临时解决措施，判断其childcount个数小于10
