### PR TITLE
修复三星手机微信6.3.11只能打开红包，不能拆红包的bug

### DIFF
--- a/app/src/main/java/xyz/monkeytong/hongbao/services/HongbaoService.java
+++ b/app/src/main/java/xyz/monkeytong/hongbao/services/HongbaoService.java
@@ -172,7 +172,13 @@ public class HongbaoService extends AccessibilityService implements SharedPrefer
         }
 
         /* 戳开红包，红包还没抢完，遍历节点匹配“拆红包” */
-        AccessibilityNodeInfo node2 = (this.rootNodeInfo.getChildCount() > 3) ? this.rootNodeInfo.getChild(3) : null;
+        AccessibilityNodeInfo node2 = null;
+        if(this.rootNodeInfo.getChildCount()==1 && "android.widget.FrameLayout".equals(this.rootNodeInfo.getChild(0).getClassName())) {
+            if(this.rootNodeInfo.getChild(0).getChildCount() > 3) {
+                node2 = this.rootNodeInfo.getChild(0).getChild(3);
+            }
+        }
+
         if (node2 != null && "android.widget.Button".equals(node2.getClassName()) && currentActivityName.contains(WECHAT_LUCKMONEY_RECEIVE_ACTIVITY)) {
             mUnpackNode = node2;
             mNeedUnpack = true;


### PR DESCRIPTION
微信6.3.11的红包界面的结构发生变化，以修改为能够正确拆红包（之前写错了版本，抱歉）
