### PR TITLE
修复当订阅号中出现标题为“[微信红包]拜年红包”（其实并非红包）的信息时误判

### DIFF
--- a/app/src/main/java/xyz/monkeytong/hongbao/services/HongbaoService.java
+++ b/app/src/main/java/xyz/monkeytong/hongbao/services/HongbaoService.java
@@ -1,7 +1,6 @@
 package xyz.monkeytong.hongbao.services;
 
 import android.accessibilityservice.AccessibilityService;
-import android.app.Instrumentation;
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.content.ComponentName;
@@ -9,18 +8,16 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.graphics.Rect;
 import android.os.Bundle;
-import android.os.IBinder;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
-import xyz.monkeytong.hongbao.activities.MainActivity;
-import xyz.monkeytong.hongbao.utils.HongbaoSignature;
-import xyz.monkeytong.hongbao.utils.PowerUtil;
 
 import java.util.List;
+
+import xyz.monkeytong.hongbao.utils.HongbaoSignature;
+import xyz.monkeytong.hongbao.utils.PowerUtil;
 
 
 public class HongbaoService extends AccessibilityService implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -131,7 +128,9 @@ public class HongbaoService extends AccessibilityService implements SharedPrefer
             return false;
 
         List<AccessibilityNodeInfo> nodes = eventSource.findAccessibilityNodeInfosByText(WECHAT_NOTIFICATION_TIP);
-        if (!nodes.isEmpty()) {
+        //增加条件判断currentActivityName.contains(WECHAT_LUCKMONEY_GENERAL_ACTIVITY)
+        //避免当订阅号中出现标题为“[微信红包]拜年红包”（其实并非红包）的信息时误判
+        if (!nodes.isEmpty() && currentActivityName.contains(WECHAT_LUCKMONEY_GENERAL_ACTIVITY)) {
             AccessibilityNodeInfo nodeToClick = nodes.get(0);
             CharSequence contentDescription = nodeToClick.getContentDescription();
             if (contentDescription != null && !signature.getContentDescription().equals(contentDescription)) {


### PR DESCRIPTION
当订阅号中出现标题为“[微信红包]拜年红包”（其实并非红包）的信息时，也会执行watchList中的AccessibilityNodeInfo.ACTION_CLICK，在if (!nodes.isEmpty())中增加条件判断，改为if (!nodes.isEmpty() && currentActivityName.contains(WECHAT_LUCKMONEY_GENERAL_ACTIVITY))，经验证可行。
